### PR TITLE
Fix an issue with CZ_DEFER working in this context.

### DIFF
--- a/include/cz/format.hpp
+++ b/include/cz/format.hpp
@@ -11,9 +11,9 @@ namespace cz {
 template <class... Ts>
 void print(FILE* file, Allocator allocator, Ts... ts) {
     String string = {};
-    CZ_DEFER(string.drop(allocator));
     append(allocator, &string, ts...);
     fwrite(string.buffer, 1, string.len, file);
+    string.drop(allocator);
 }
 
 template <class... Ts>


### PR DESCRIPTION
CZ_DEFER was not working in this context, leading to errors when compiling with g++.

Remove the CZ_DEFER and manually move the drop to the end.

Fixes #1